### PR TITLE
Fixed typo in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -53,4 +53,4 @@ This project is a web-based application designed to facilitate circuit design an
 
 1. Clone the repository:
    ```sh
-   git clone https://github.com/patilyashh/electronics-circuit-simulato.git
+   git clone https://github.com/PATILYASHH/electronics-circuit-simulator.git


### PR DESCRIPTION
I was reading the readme for solving the issue of [Tools Dropdown](https://github.com/PATILYASHH/electronics-circuit-simulator/issues/9).

However, in the installation section of Readme.md, there was a typo (missing r in simulator):
![Screenshot 2024-08-08 112501](https://github.com/user-attachments/assets/2a9809a4-ddf2-43dc-b45c-24c96df2d907)

The typo has been fixed now.

@PATILYASHH please review the PR and merge it to avoid many people facing this issue.

I would like to work on the Tools Dropdown issue now. Thanks!